### PR TITLE
Removed Coloring

### DIFF
--- a/src/ASRWidget.cpp
+++ b/src/ASRWidget.cpp
@@ -60,22 +60,7 @@ void ASRWidget::OnMessage(std::string topic, std::string message) {
     string text = response["data"]["text"];
     string participant_id = response["data"]["participant_id"];
     string time_stamp = response["header"]["timestamp"];
-    if (participant_color.find(participant_id) != participant_color.end()) {
-      update["color"] = participant_color.at(participant_id);
-    } else {
-      nlohmann::json trial_message = trial_listener->GetTrialMessage();
-      vector<nlohmann::json> client_info =
-          trial_message["data"]["client_info"].get<vector<nlohmann::json>>();
-      for (nlohmann::json client : client_info) {
-        if (client["participant_id"] == participant_id) {
-          string color = client["callsign"];
-          boost::algorithm::to_lower(color);
-          participant_color[participant_id] = color;
-          update["color"] = color;
-        }
-      }
-    }
-
+    
     update["text"] = text;
     update["participant_id"] = participant_id;
     update["timestamp"] = time_stamp;
@@ -97,17 +82,10 @@ void ASRWidget::Update() {
     string participant_id = update["participant_id"];
     string text = update["text"];
     string time_stamp = update["timestamp"];
-    string color = update["color"];
-
     text_box->BeginFontSize(9);
     text_box->WriteText(time_stamp + " ");
-
     text_box->BeginFontSize(14);
-    wxString s(color);
-    text_box->SetDefaultStyle(wxTextAttr(s));
     text_box->WriteText(participant_id + ": ");
-
-    text_box->SetDefaultStyle(wxTextAttr("white"));
     text_box->WriteText(text + "\n");
     text_box->ScrollIntoView(text_box->GetCaretPosition(), WXK_PAGEDOWN);
   }


### PR DESCRIPTION
Hey Adarsh- 

The pull request took me time because I figured the dashboard only prints messages with the participants id (BLUE_ASIST_1) with the new metadata instead of the numeric participants id. 
Tried figuring out whether it was some mistake but it does what it was originally implemented by Vincent. Figured you might want to know this. 